### PR TITLE
BACKLOG-16589: Fixed invalid singleton config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <properties>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MCwCFAYVb7/1rsSKfvsNlJTEHRyjVGcbAhQ43tXpFtNQdrQNjn0TVmXGtwJQLA==</jahia-module-signature>
+        <jahia-module-signature>MCwCFA3YNryccdEVuJB8a5Csl9/9iIptAhQYzu6bF5unz2CnufxEoRiLI6frjw==</jahia-module-signature>
         <yarn.arguments>build:production</yarn.arguments>
     </properties>
 

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -55,25 +55,19 @@ const notImported = [
     '@jahia/moonstone'
 ];
 
-module.exports = {
-    ...sharedDeps.reduce((acc, item) => ({
-        ...acc,
-        [item]: {
-            requiredVersion: deps[item]
-        }
-    }), {}),
-    ...singletonDeps.reduce((acc, item) => ({
-        ...acc,
-        [item]: {
-            singleton: true,
-            requiredVersion: deps[item]
-        }
-    }), {}),
-    ...notImported.reduce((acc, item) => ({
-        ...acc,
-        [item]: {
-            import: false,
-            requiredVersion: deps[item]
-        }
-    }), {})
-};
+const shared = sharedDeps.filter(item => deps[item]).reduce((acc, item) => ({
+    ...acc,
+    [item]: {
+        requiredVersion: deps[item]
+    }
+}), {});
+
+singletonDeps.filter(item => shared[item]).forEach(item => {
+    shared[item].singleton = true;
+});
+
+notImported.filter(item => shared[item]).forEach(item => {
+    shared[item].import = false;
+});
+
+module.exports = shared;


### PR DESCRIPTION
The "notImported" is actually removing the singleton flag, making webpack load multiple versions of moonstone 