### PR TITLE
fix: Re-order 'open in page composer' action

### DIFF
--- a/src/javascript/PageComposer/PageComposer.actions.jsx
+++ b/src/javascript/PageComposer/PageComposer.actions.jsx
@@ -6,6 +6,7 @@ export const pageComposerActions = registry => {
     registry.add('action', 'pageComposer', pageComposerAction, {
         buttonLabel: 'jcontent:label.contentManager.actions.pageComposer',
         buttonIcon: <OpenInBrowser/>,
-        targets: ['narrowHeaderMenu:10.5', 'browseControlBar:12', 'contentItemActions:21', 'contentItemContextActions:22']
+        // Target just before contentActionsSeparator3 in jContent
+        targets: ['narrowHeaderMenu:49', 'browseControlBar:49', 'contentItemActions:49', 'contentItemContextActions:49']
     });
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Related PR https://github.com/Jahia/jcontent/pull/1589

Adjust target priority for 'open in page composer' action so that it appears just before the the last separator defined in the menus (hardcoded with priority 50)