### PR TITLE
fix: Make data-helper a singleton

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -46,6 +46,7 @@ const singletonDeps = [
     'redux',
     '@jahia/moonstone',
     '@jahia/ui-extender',
+    '@jahia/data-helper',
     '@apollo/react-common',
     '@apollo/react-components',
     '@apollo/react-hooks'


### PR DESCRIPTION
### Description
Remove fragment warnings from console by preventing multiple instances of data-helper so that fragments are registered only once.

Info about the issue: multiple modules can load different versions of data-helper. Since it contains fragments they can get registered with every instantiation. Graphql tag shows a warning once they detect a duplicate fragment as they all live in one object. This can be prevented by only loading one data-helper instance at all times.

Ideally this should be done via unified federation config that we have in javascript-components. There will be a separate story to have that updated and implemented in all Jahia 8 modules for ease of modification and consistency.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
