### PR TITLE
ci: Update @jahia/cypress version from 4.5.0 to 8.0.0

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jahia/content-editor-cypress": "^4.2.0-tests.9",
-    "@jahia/cypress": "^4.5.0",
+    "@jahia/cypress": "^8.0.0",
     "@jahia/jahia-reporter": "^1.0.30",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -106,10 +106,10 @@
   resolved "https://registry.yarnpkg.com/@jahia/content-editor-cypress/-/content-editor-cypress-4.2.0-tests.9.tgz#1d899ce2a78638e7847eccf5c13c242681be1eb7"
   integrity sha512-aJN0Z62EPs82AbiCU9wqEgmzxrZdu3nWm06GpTvMh05FYdv6DeF86bml2IldehGBn8NJCIIy26vA88GL6OJQKw==
 
-"@jahia/cypress@^4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-4.5.0.tgz#0bdf76d0b4a9571065f5800aff52d277183edabd"
-  integrity sha512-2DKhUP/68AOQ+4dHUBdJPbVbMD8JgUaHTcBpS2ZBzC4oLfQAckFJPuX/itr4IusuziX2M6CuOjmR2rsHYGWU6g==
+"@jahia/cypress@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-8.0.0.tgz#def0ae1adea3362911227fbb00270b45afe7073c"
+  integrity sha512-MgDuQISA7NgId2tghRo0wltvkNS8i24QKtidVD6jbdHtjw73EjA5d6WrRQwqittxcQ37kMG/fHjMEmTXiB/8iw==
   dependencies:
     "@apollo/client" "^3.4.9"
     cypress-real-events "^1.11.0"


### PR DESCRIPTION
### Description

Fix failing nightly run - release

From https://github.com/Jahia/jahia-page-composer/actions/runs/21930045118/job/63331765239#step:6:468, we have the same CI build error described here: https://github.com/Jahia/jahia-cypress/issues/188

Bump to latest @jahia/cypress module to update cypress image

